### PR TITLE
Negative digit filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.phar
 /vendor/
 /test/.phpunit.cache
 /test/html-coverage
+.idea/

--- a/src/NegativeDigits.php
+++ b/src/NegativeDigits.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalt\Filter;
+
+use Laminas\Filter\Digits;
+
+class NegativeDigits extends Digits
+{
+    public function filter($value)
+    {
+        $isNegative = str_starts_with('-', $value);
+
+        $filteredValue = parent::filter($value);
+
+        if ($isNegative) {
+            return '-' . $filteredValue;
+        }
+
+        return $filteredValue;
+    }
+}

--- a/src/NegativeDigits.php
+++ b/src/NegativeDigits.php
@@ -10,11 +10,9 @@ class NegativeDigits extends Digits
 {
     public function filter($value)
     {
-        $isNegative = str_starts_with('-', $value);
-
         $filteredValue = parent::filter($value);
 
-        if ($isNegative) {
+        if (!is_int($value) && str_starts_with((string) $value, '-')) {
             return '-' . $filteredValue;
         }
 

--- a/test/NegativeDigitsTest.php
+++ b/test/NegativeDigitsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalt\Filter;
+
+use PHPUnit\Framework\TestCase;
+
+class NegativeDigitsTest extends TestCase
+{
+    public static function correctPositiveNumbersProvider(): array
+    {
+        return [
+            [123, '123'],
+            ['234', '234'],
+            [123.45, '12345'],
+            ['345.45', '34545'],
+        ];
+    }
+
+    public static function correctNegativeNumbersProvider(): array
+    {
+        return [
+            [-123, '-123'],
+            ['-234', '-234'],
+            [-123.45, '-12345'],
+            ['-345.45', '-34545'],
+        ];
+    }
+
+    public static function incorrectNumbersProvider(): array
+    {
+        return [
+            ['1s2d3', '123'],
+            ['-2a3b4', '-234'],
+            ['1a2b3c.d4e5f', '12345'],
+            ['-a3a4b5.45', '-34545'],
+            ['0-abc1', '01'],
+            ['----abde12', '-12'],
+            ['--23', '-23']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider correctPositiveNumbersProvider
+     * @dataProvider correctNegativeNumbersProvider
+     * @dataProvider incorrectNumbersProvider
+     */
+    public function numbersAreCorrectlyFiltered(float|int|string $input, string $expectedFilteredOutput): void
+    {
+        $negativeDigitsFilter = new NegativeDigits();
+
+        $actualFilteredOutput = $negativeDigitsFilter->filter($input);
+
+        $this->assertSame($expectedFilteredOutput, $actualFilteredOutput,);
+    }
+}


### PR DESCRIPTION
Adds a filter for filtering negative numbers/digits. Since the default laminas Digits filter doesn't allow negative string numbers or floats.